### PR TITLE
taskProvider: Add support for the tasks defined on .code-workspace file

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -14,9 +14,13 @@
             "group": {
                 "kind": "build",
                 "isDefault": true
-            }
+            },
+            "dependsOn": [
+                "extension-compile"
+            ]
         },
         {
+            "label": "extension-compile",
             "type": "npm",
             "script": "compile",
             "problemMatcher": [


### PR DESCRIPTION
Add support for the tasks defined on the .code-workspace file, on
multiroot workspaces.

Signed-off-by: Andre Riesco <andre.riesco@toradex.com>